### PR TITLE
Release to PyPi

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -1,0 +1,33 @@
+name: Publish package to PyPi
+
+on:
+  release:
+    types: [published]
+
+jobs:
+
+  push:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: setup python
+        uses: actions/setup-python@v3
+        with:
+          python-version: 3.8
+
+      - name: Install pip
+        run: pip install pip
+
+      - name: Install Dependencies
+        run: pip install setuptools wheel
+
+      - name: Build package
+        run: python setup.py sdist bdist_wheel
+
+      - name: Publish to PyPi
+        uses: pypa/gh-action-pypi-publish@master
+        with:
+          user: __token__
+          password: ${{ secrets.PYPI_UPLOAD_TOKEN }}

--- a/require/__init__.py
+++ b/require/__init__.py
@@ -7,4 +7,4 @@ Developed by Dave Hall.
 """
 
 
-__version__ = (1, 0, 12)
+__version__ = (2, 0, 0)

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,18 @@
-from distutils.core import setup
+from setuptools import setup
 
 from require import __version__
-
 
 version_str = ".".join(str(n) for n in __version__)
 
 
 setup(
-    name = "django-require",
+    name = "openedx-django-require",
     version = version_str,
     license = "BSD",
     description = "A Django staticfiles post-processor for optimizing with RequireJS.",
     author = "Dave Hall",
     author_email = "dave@etianen.com",
+    maintainer="edX",
     url = "https://github.com/etianen/django-require",
     packages = [
         "require",
@@ -31,16 +31,12 @@ setup(
         "Development Status :: 5 - Production/Stable",
         "Environment :: Web Environment",
         "Framework :: Django",
+        "Framework :: Django :: 3.2",
         "Intended Audience :: Developers",
         "License :: OSI Approved :: BSD License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 2",
-        "Programming Language :: Python :: 2.7",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.2",
-        "Programming Language :: Python :: 3.3",
-        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.8",
         "Topic :: Internet :: WWW/HTTP",
     ],
 )


### PR DESCRIPTION
This PR adds workflow to release the package to PyPI. It also updates the trove classifiers. Adding a major bump in the version because we have dropped support for older python and django versions in previous PR which will be released in this version.

Tested the release on test PyPI: https://test.pypi.org/project/openedx-django-require/2.0.0/